### PR TITLE
Set bot ID

### DIFF
--- a/terraform/ecs-task-definition.tf
+++ b/terraform/ecs-task-definition.tf
@@ -81,6 +81,11 @@ locals {
         name  = "INCIDENT_BOT_NAME",
         value = "opgincidentresponse"
       },
+
+      {
+        name  = "INCIDENT_BOT_ID",
+        value = "A01CXL45ZE1"
+      },
       {
         name  = "INCIDENT_CHANNEL_NAME",
         value = "opg-incident"


### PR DESCRIPTION
Attempt setting the bot ID directly to avoid a lookup and narrow down where an error is occurring