### PR TITLE
Disable auth in dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,20 +14,20 @@ Response is a Django app which you can include in your project. Check out the [o
 
 Copy `env.dev.example` to `.env` to configure environment variables. All environment variables need to be set, but some can set to blank values (i.e. `ENV_VAR=`) as detailed below.
 
-| Variable                     | Value required?            | Details                                                                                             |
-| ---------------------------- | -------------------------- | --------------------------------------------------------------------------------------------------- |
-| SECRET_KEY                   | Yes                        | Used by Django, can be set to anything                                                              |
-| DJANGO_SETTINGS_MODULE       | Yes                        | Specifies which settings to use. Should be `opgincidentresponse.settings.dev` in local environments |
-| SOCIAL_AUTH_\*               | Yes                        | Used to authenticate with GitHub. Get the localhost app settings from WebOps                        |
-| SLACK_TOKEN                  | Yes                        | Provided when you create a Slack app                                                                |
-| SLACK_SIGNING_SECRET         | Yes                        | Provided when you create a Slack app                                                                |
-| SLACK_TEAM_ID                | Yes                        | You should test in a private team, not MOJD&T                                                       |
-| INCIDENT_BOT_ID              | Yes                        | The ID of your test app                                                                             |
-| INCIDENT_BOT_NAME            | Yes                        | The name of your test app                                                                           |
-| INCIDENT_CHANNEL_NAME        | Yes                        | The channel to post new live incidents to                                                           |
-| INCIDENT_REPORT_CHANNEL_NAME | Yes                        | The channel to post new incident reports to                                                         |
-| STATUSPAGEIO_API_KEY         | Only if testing Statuspage | Provided by Statuspage                                                                              |
-| STATUSPAGEIO_PAGE_ID         | Only if testing Statuspage | Provided by Statuspage                                                                              |
-| PAGERDUTY_API_KEY            | Only if testing PagerDuty  | Provided by Pagerduty                                                                               |
-| PAGERDUTY_EMAIL              | Only if testing PagerDuty  | Provided by Pagerduty                                                                               |
-| PAGERDUTY_SERVICE            | Only if testing PagerDuty  | Provided by Pagerduty                                                                               |
+| Variable                     | Value required?                | Details                                                                                             |
+| ---------------------------- | ------------------------------ | --------------------------------------------------------------------------------------------------- |
+| SECRET_KEY                   | Yes                            | Used by Django, can be set to anything                                                              |
+| DJANGO_SETTINGS_MODULE       | Yes                            | Specifies which settings to use. Should be `opgincidentresponse.settings.dev` in local environments |
+| SOCIAL_AUTH_\*               | Only if testing authentication | There's already a dev/localhost and production GitHub app you can use                               |
+| SLACK_TOKEN                  | Yes                            | Provided when you create a Slack app                                                                |
+| SLACK_SIGNING_SECRET         | Yes                            | Provided when you create a Slack app                                                                |
+| SLACK_TEAM_ID                | Yes                            | You should test in a private team, not MOJD&T                                                       |
+| INCIDENT_BOT_ID              | Yes                            | The ID of your test app                                                                             |
+| INCIDENT_BOT_NAME            | Yes                            | The name of your test app                                                                           |
+| INCIDENT_CHANNEL_NAME        | Yes                            | The channel to post new live incidents to                                                           |
+| INCIDENT_REPORT_CHANNEL_NAME | Yes                            | The channel to post new incident reports to                                                         |
+| STATUSPAGEIO_API_KEY         | Only if testing Statuspage     | Provided by Statuspage                                                                              |
+| STATUSPAGEIO_PAGE_ID         | Only if testing Statuspage     | Provided by Statuspage                                                                              |
+| PAGERDUTY_API_KEY            | Only if testing PagerDuty      | Provided by Pagerduty                                                                               |
+| PAGERDUTY_EMAIL              | Only if testing PagerDuty      | Provided by Pagerduty                                                                               |
+| PAGERDUTY_SERVICE            | Only if testing PagerDuty      | Provided by Pagerduty                                                                               |

--- a/opgincidentresponse/settings/base.py
+++ b/opgincidentresponse/settings/base.py
@@ -235,3 +235,6 @@ LOGIN_URL = "login/github-org"
 # Whether to use https://pypi.org/project/bleach/ to strip potentially dangerous
 # HTML input in string fields
 RESPONSE_SANITIZE_USER_INPUT = True
+
+# Whether users need to log in to access Response
+RESPONSE_LOGIN_REQUIRED = True

--- a/opgincidentresponse/views.py
+++ b/opgincidentresponse/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.http import Http404, HttpRequest
 from django.shortcuts import render
@@ -5,12 +6,18 @@ from django.shortcuts import render
 from response.core.models import Action, Incident
 from response.slack.models import PinnedMessage, UserStats
 
-@login_required
+def bypassable_login_required(func):
+    if settings.RESPONSE_LOGIN_REQUIRED:
+        return login_required(func)
+    else:
+        return func
+
+@bypassable_login_required
 def home(request: HttpRequest):
     incidents = Incident.objects.all().order_by('-end_time')
     return render(request, template_name="index.html", context={"incidents": incidents})
 
-@login_required
+@bypassable_login_required
 def incident(request: HttpRequest, incident_id: str):
     try:
         incident = Incident.objects.get(pk=incident_id)


### PR DESCRIPTION
Can be re-enabled by changing `RESPONSE_LOGIN_REQUIRED` to True in `dev.py`

Allows local development without setting up GitHub apps