### PR TITLE
Treat the status page component as optional

### DIFF
--- a/opgincidentresponse/actions/statuspage.py
+++ b/opgincidentresponse/actions/statuspage.py
@@ -167,9 +167,12 @@ def update_status_page(
         "name": submission["name"],
         "status": submission["incident_status"],
         "message": submission["message"] or "",
-        "component_ids": [submission["component_id"]],
         "component_status": submission["component_status"],
     }
+
+    if submission["component_id"]:
+        statuspage_incident["component_ids"] = [submission["component_id"]]
+
     if submission["impact_override"]:
         statuspage_incident["impact_override"] = submission["impact_override"]
 

--- a/opgincidentresponse/models.py
+++ b/opgincidentresponse/models.py
@@ -41,7 +41,7 @@ class StatusPage(models.Model):
             self.statuspage_incident_id = response["id"]
             self.save()
 
-        if kwargs['component_ids']:
+        if 'component_ids' in kwargs and kwargs['component_ids']:
                 if kwargs['status'] == 'resolved':
                     status = 'operational'
                 else:
@@ -56,14 +56,18 @@ class StatusPage(models.Model):
         if self.statuspage_incident_id:
             for incident in statuspage_client().incidents.list():
                 if incident["id"] == self.statuspage_incident_id:
-                    return {
+                    obj = {
                         "name": incident["name"],
                         "status": incident["status"],
                         "message": incident["incident_updates"][0]["body"],
                         "impact_override": incident["impact_override"],
-                        "component_id": incident["components"][0]["id"],
-                        "component_status": incident["components"][0]["status"],
                     }
+
+                    if len(incident["components"]) > 0:
+                        obj["component_id"] = incident["components"][0]["id"]
+                        obj["component_status"] = incident["components"][0]["status"]
+
+                    return obj
             raise StatusPageError(
                 f"Statuspage incident with id {self.statuspage_incident_id} not found"
             )


### PR DESCRIPTION
Although the field is marked as optional, we expect it to be present when creating, reading and updating incidents.

These changes ensure you can have an entire incident with no reference to a statuspage component