### PR TITLE
Use incident title rather than summary on index

### DIFF
--- a/opgincidentresponse/templates/index.html
+++ b/opgincidentresponse/templates/index.html
@@ -21,7 +21,7 @@
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">
                         <a class="govuk-link" href="/incident/{{ incident.id }}">
-                            {{ incident.summary }}
+                            {{ incident.report | unslackify }}
                         </a>
                     </th>
                     <td class="govuk-table__header">


### PR DESCRIPTION
The summaries are much longer and make the page really hard to parse