### PR TITLE
Going directly to an incident page does not take you through the login journey

### DIFF
--- a/opgincidentresponse/settings/base.py
+++ b/opgincidentresponse/settings/base.py
@@ -230,7 +230,7 @@ PAGERDUTY_API_KEY = get_env_var("PAGERDUTY_API_KEY")
 PAGERDUTY_SERVICE = get_env_var("PAGERDUTY_SERVICE")
 PAGERDUTY_EMAIL = get_env_var("PAGERDUTY_EMAIL")
 
-LOGIN_URL = "login/github-org"
+LOGIN_URL = "/login/github-org"
 
 # Whether to use https://pypi.org/project/bleach/ to strip potentially dangerous
 # HTML input in string fields

--- a/opgincidentresponse/templates/govuk_base.html
+++ b/opgincidentresponse/templates/govuk_base.html
@@ -93,7 +93,7 @@
             ></image>
           </svg>
 
-          <a class="moj-header__link moj-header__link--service-name" href="#">OPG Incident Response</a>
+          <a class="moj-header__link moj-header__link--service-name" href="/">OPG Incident Response</a>
       </div>
       <div class="moj-header__content">
 
@@ -101,7 +101,7 @@
 
           <ul class="moj-header__navigation-list">
             <li class="moj-header__navigation-item">
-              <a class="moj-header__navigation-link" href="#">Sign out</a>
+              Signed in via GitHub as <strong>{{ backends.associated.first }}</strong>
             </li>
           </ul>
 


### PR DESCRIPTION
It just need a preceding slash 🤦 

I also removed the "Sign out" link because it doesn't do anything and—in our current setup—can't

Fixes #50 
