### PR TITLE
Bump node from 19.0.0-alpine3.16 to 19.0.1-alpine3.16

### DIFF
--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,4 +1,4 @@
-FROM node:19.0.0-alpine3.16 as asset-env
+FROM node:19.0.1-alpine3.16 as asset-env
 
 WORKDIR /app
 


### PR DESCRIPTION
Bumps node from 19.0.0-alpine3.16 to 19.0.1-alpine3.16.

---
updated-dependencies:
- dependency-name: node dependency-type: direct:production update-type: version-update:semver-patch ...

Signed-off-by: dependabot[bot] <support@github.com>