### PR TITLE
Bump wait on check.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Wait for build
-        uses: lewagon/wait-on-check-action@v0.2
+        uses: lewagon/wait-on-check-action@v1.0.0
         with:
           ref: main
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Wait on check seems to be blocking deploy due to older action not supporting skipped workflows.